### PR TITLE
feat: vitest test suite with pipeline modules

### DIFF
--- a/src/lib/pipeline/__tests__/parse-jd.test.ts
+++ b/src/lib/pipeline/__tests__/parse-jd.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { stripHtml, normalizeWhitespace, isHtml, parseJd } from "../parse-jd";
+
+const fixturesDir = join(__dirname, "fixtures");
+const sampleJdTxt = readFileSync(join(fixturesDir, "sample-jd.txt"), "utf-8");
+const sampleJdHtml = readFileSync(join(fixturesDir, "sample-jd.html"), "utf-8");
+
+describe("isHtml", () => {
+  it("detects HTML input", () => {
+    expect(isHtml("<p>Hello</p>")).toBe(true);
+    expect(isHtml("<!DOCTYPE html><html></html>")).toBe(true);
+  });
+
+  it("returns false for plain text", () => {
+    expect(isHtml("Staff Software Engineer\nDataFlow Inc")).toBe(false);
+    expect(isHtml("Just plain text")).toBe(false);
+  });
+});
+
+describe("stripHtml", () => {
+  it("removes HTML tags", () => {
+    const result = stripHtml("<h1>Job Title</h1><p>Description</p>");
+    expect(result).not.toMatch(/<[^>]+>/);
+    expect(result).toContain("Job Title");
+    expect(result).toContain("Description");
+  });
+
+  it("decodes HTML entities", () => {
+    expect(stripHtml("&amp; &lt; &gt; &quot; &#39; &nbsp;")).toBe(
+      "& < > \" ' " + " "
+    );
+  });
+
+  it("removes script and style blocks entirely", () => {
+    const html = "<script>alert('xss')</script><p>Content</p><style>body{}</style>";
+    const result = stripHtml(html);
+    expect(result).not.toContain("alert");
+    expect(result).not.toContain("body{}");
+    expect(result).toContain("Content");
+  });
+
+  it("converts block elements to newlines", () => {
+    const html = "<p>Line one</p><p>Line two</p>";
+    const result = stripHtml(html);
+    expect(result).toContain("\n");
+  });
+
+  it("strips HTML from sample-jd.html fixture", () => {
+    const result = stripHtml(sampleJdHtml);
+    expect(result).not.toMatch(/<[^>]+>/);
+    expect(result).toContain("Staff Software Engineer");
+    expect(result).toContain("DataFlow Inc");
+  });
+});
+
+describe("normalizeWhitespace", () => {
+  it("trims lines and removes blank lines", () => {
+    const input = "  line one  \n\n   line two   \n\n";
+    const result = normalizeWhitespace(input);
+    expect(result).toBe("line one\nline two");
+  });
+
+  it("handles already-clean text", () => {
+    const input = "line one\nline two";
+    expect(normalizeWhitespace(input)).toBe("line one\nline two");
+  });
+});
+
+describe("parseJd", () => {
+  it("parses plain text JD without modification beyond normalization", () => {
+    const result = parseJd(sampleJdTxt);
+    expect(result).toContain("Staff Software Engineer");
+    expect(result).toContain("DataFlow Inc");
+    expect(result).toContain("Kafka");
+  });
+
+  it("parses HTML JD by stripping tags and normalizing", () => {
+    const result = parseJd(sampleJdHtml);
+    expect(result).not.toMatch(/<[^>]+>/);
+    expect(result).toContain("Staff Software Engineer");
+    expect(result).toContain("DataFlow Inc");
+    expect(result).toContain("Kafka");
+  });
+
+  it("HTML and text fixtures produce similar key content", () => {
+    const fromText = parseJd(sampleJdTxt);
+    const fromHtml = parseJd(sampleJdHtml);
+    // Both should contain the same key phrases
+    const keyPhrases = ["Staff Software Engineer", "DataFlow Inc", "Kafka", "Flink"];
+    for (const phrase of keyPhrases) {
+      expect(fromText).toContain(phrase);
+      expect(fromHtml).toContain(phrase);
+    }
+  });
+
+  it("returns non-empty output for valid input", () => {
+    expect(parseJd(sampleJdTxt).length).toBeGreaterThan(100);
+    expect(parseJd(sampleJdHtml).length).toBeGreaterThan(100);
+  });
+});

--- a/src/lib/pipeline/__tests__/validate.test.ts
+++ b/src/lib/pipeline/__tests__/validate.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import type { MasterResume, TailoredResume } from "../../types";
+import { validateMasterResume, validateTailoredResume } from "../validate";
+import masterResumeFixture from "./fixtures/master-resume.json";
+import tailoredResumeFixture from "./fixtures/tailored-resume.json";
+
+const validMaster = masterResumeFixture as MasterResume;
+const validTailored = tailoredResumeFixture as TailoredResume;
+
+describe("validateMasterResume", () => {
+  it("passes for the fixture resume", () => {
+    const result = validateMasterResume(validMaster);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("returns a score for a valid resume", () => {
+    const result = validateMasterResume(validMaster);
+    expect(result.score).toBeGreaterThan(0);
+    expect(result.score).toBeLessThanOrEqual(100);
+  });
+
+  it("fails when name is missing", () => {
+    const resume: MasterResume = { ...validMaster, name: "" };
+    const result = validateMasterResume(resume);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("name is required");
+  });
+
+  it("fails when email is missing", () => {
+    const resume: MasterResume = { ...validMaster, email: "" };
+    const result = validateMasterResume(resume);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("email is required");
+  });
+
+  it("fails when email format is invalid", () => {
+    const resume: MasterResume = { ...validMaster, email: "not-an-email" };
+    const result = validateMasterResume(resume);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("email format is invalid");
+  });
+
+  it("fails when experience is empty", () => {
+    const resume: MasterResume = { ...validMaster, experience: [] };
+    const result = validateMasterResume(resume);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("experience must have at least one entry");
+  });
+
+  it("fails when education is empty", () => {
+    const resume: MasterResume = { ...validMaster, education: [] };
+    const result = validateMasterResume(resume);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("education must have at least one entry");
+  });
+
+  it("warns when an experience entry has no bullets", () => {
+    const resume: MasterResume = {
+      ...validMaster,
+      experience: [
+        { ...validMaster.experience[0], bullets: [] },
+        ...validMaster.experience.slice(1),
+      ],
+    };
+    const result = validateMasterResume(resume);
+    expect(result.warnings).toContain("experience[0] has no bullets");
+  });
+
+  it("accumulates multiple errors", () => {
+    const resume: MasterResume = { ...validMaster, name: "", email: "", phone: "" };
+    const result = validateMasterResume(resume);
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("score is 0 when there are errors", () => {
+    const resume: MasterResume = { ...validMaster, name: "" };
+    const result = validateMasterResume(resume);
+    expect(result.score).toBe(0);
+  });
+});
+
+describe("validateTailoredResume", () => {
+  it("passes for the fixture tailored resume", () => {
+    const result = validateTailoredResume(validTailored);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("returns a score for a valid tailored resume", () => {
+    const result = validateTailoredResume(validTailored);
+    expect(result.score).toBeGreaterThan(0);
+  });
+
+  it("fails when jobTitle is missing", () => {
+    const tailored: TailoredResume = { ...validTailored, jobTitle: "" };
+    const result = validateTailoredResume(tailored);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("jobTitle is required");
+  });
+
+  it("fails when company is missing", () => {
+    const tailored: TailoredResume = { ...validTailored, company: "" };
+    const result = validateTailoredResume(tailored);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("company is required");
+  });
+
+  it("fails when jobDescription is missing", () => {
+    const tailored: TailoredResume = { ...validTailored, jobDescription: "" };
+    const result = validateTailoredResume(tailored);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("jobDescription is required");
+  });
+
+  it("fails when matchScore is out of range", () => {
+    const tailored: TailoredResume = { ...validTailored, matchScore: 150 };
+    const result = validateTailoredResume(tailored);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("matchScore must be between 0 and 100");
+  });
+
+  it("warns when matchScore is below 50", () => {
+    const tailored: TailoredResume = { ...validTailored, matchScore: 40 };
+    const result = validateTailoredResume(tailored);
+    expect(result.warnings).toContain(
+      "matchScore is below 50 — consider better aligning the resume"
+    );
+  });
+
+  it("propagates nested resume errors with prefix", () => {
+    const tailored: TailoredResume = {
+      ...validTailored,
+      resume: { ...validTailored.resume, name: "" },
+    };
+    const result = validateTailoredResume(tailored);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("resume.name is required");
+  });
+});

--- a/src/lib/pipeline/parse-jd.ts
+++ b/src/lib/pipeline/parse-jd.ts
@@ -1,0 +1,37 @@
+/**
+ * Parses job description text from raw HTML or plain text input.
+ * Returns clean, normalized plain text suitable for AI processing.
+ */
+export function stripHtml(html: string): string {
+  return html
+    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "")
+    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/p>/gi, "\n")
+    .replace(/<\/li>/gi, "\n")
+    .replace(/<\/h[1-6]>/gi, "\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, " ");
+}
+
+export function normalizeWhitespace(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .join("\n");
+}
+
+export function isHtml(input: string): boolean {
+  return /<[a-z][\s\S]*>/i.test(input);
+}
+
+export function parseJd(input: string): string {
+  const text = isHtml(input) ? stripHtml(input) : input;
+  return normalizeWhitespace(text);
+}

--- a/src/lib/pipeline/validate.ts
+++ b/src/lib/pipeline/validate.ts
@@ -1,0 +1,85 @@
+import type { MasterResume, TailoredResume, ValidationResult } from "../types";
+
+export function validateMasterResume(resume: MasterResume): ValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  // Required top-level fields
+  if (!resume.name?.trim()) errors.push("name is required");
+  if (!resume.email?.trim()) errors.push("email is required");
+  if (!resume.phone?.trim()) errors.push("phone is required");
+  if (!resume.location?.trim()) errors.push("location is required");
+
+  // Email format
+  if (resume.email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(resume.email)) {
+    errors.push("email format is invalid");
+  }
+
+  // Experience
+  if (!Array.isArray(resume.experience) || resume.experience.length === 0) {
+    errors.push("experience must have at least one entry");
+  } else {
+    resume.experience.forEach((exp, i) => {
+      if (!exp.company?.trim()) errors.push(`experience[${i}].company is required`);
+      if (!exp.title?.trim()) errors.push(`experience[${i}].title is required`);
+      if (!Array.isArray(exp.bullets) || exp.bullets.length === 0) {
+        warnings.push(`experience[${i}] has no bullets`);
+      }
+    });
+  }
+
+  // Education
+  if (!Array.isArray(resume.education) || resume.education.length === 0) {
+    errors.push("education must have at least one entry");
+  } else {
+    resume.education.forEach((edu, i) => {
+      if (!edu.institution?.trim()) errors.push(`education[${i}].institution is required`);
+      if (!edu.degree?.trim()) errors.push(`education[${i}].degree is required`);
+    });
+  }
+
+  // Skills
+  if (!Array.isArray(resume.skills) || resume.skills.length === 0) {
+    warnings.push("no skills entries found");
+  }
+
+  const score = errors.length === 0 ? Math.max(0, 100 - warnings.length * 5) : 0;
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+    score,
+  };
+}
+
+export function validateTailoredResume(tailored: TailoredResume): ValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  if (!tailored.jobTitle?.trim()) errors.push("jobTitle is required");
+  if (!tailored.company?.trim()) errors.push("company is required");
+  if (!tailored.jobDescription?.trim()) errors.push("jobDescription is required");
+
+  if (tailored.matchScore !== undefined) {
+    if (tailored.matchScore < 0 || tailored.matchScore > 100) {
+      errors.push("matchScore must be between 0 and 100");
+    }
+    if (tailored.matchScore < 50) {
+      warnings.push("matchScore is below 50 — consider better aligning the resume");
+    }
+  }
+
+  const resumeValidation = validateMasterResume(tailored.resume);
+  errors.push(...resumeValidation.errors.map((e) => `resume.${e}`));
+  warnings.push(...resumeValidation.warnings.map((w) => `resume.${w}`));
+
+  const score = errors.length === 0 ? Math.max(0, 100 - warnings.length * 5) : 0;
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+    score,
+  };
+}


### PR DESCRIPTION
## Summary
- Configures Vitest with jsdom, React plugin, `@` path alias, and `src/test-setup.ts`
- Adds `parse-jd` pipeline module: HTML stripping, whitespace normalization, auto-detection of HTML vs plain text
- Adds `validate` pipeline module: field-level validation for `MasterResume` and `TailoredResume` with error/warning accumulation and scoring
- Adds 35 tests across 3 files, all passing (`npm test`)

## Test plan
- [ ] `npm test` — all 35 tests pass
- [ ] `types.test.ts` (4 tests): fixture shapes, `ValidationResult`, `PipelineResult` construction
- [ ] `parse-jd.test.ts` (13 tests): `isHtml`, `stripHtml` (tag removal, entity decoding, XSS), `normalizeWhitespace`, `parseJd` on both fixtures
- [ ] `validate.test.ts` (18 tests): valid fixture passes, missing required fields fail, email format, out-of-range score, low-score warning, nested error prefixing

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)