### PR TITLE
feat: Phase 1C — API routes /api/tailor, /api/fetch-jd, /api/profile

### DIFF
--- a/src/app/api/fetch-jd/route.ts
+++ b/src/app/api/fetch-jd/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchJobDescription } from '../../../lib/pipeline/step2-fetch-jd';
+
+export async function POST(req: NextRequest) {
+  let body: { url: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const { url } = body;
+  if (!url || typeof url !== 'string') {
+    return NextResponse.json({ error: 'url is required' }, { status: 400 });
+  }
+
+  try {
+    const text = await fetchJobDescription(url);
+    return NextResponse.json({ text });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import type { MasterResume } from '../../../lib/types';
+import { loadProfile } from '../../../lib/pipeline/step1-load-profile';
+import { getFixtureMasterResume } from '../../../lib/pipeline/seed';
+import { validateMasterResume } from '../../../lib/pipeline/validate';
+
+const PROFILE_DIR = path.join(os.homedir(), '.resume-app');
+const PROFILE_PATH = path.join(PROFILE_DIR, 'profile.json');
+
+export async function GET() {
+  try {
+    let profile: MasterResume;
+    try {
+      profile = await loadProfile(PROFILE_PATH);
+    } catch {
+      // Seed from fixture on first run
+      profile = await getFixtureMasterResume();
+      await fs.mkdir(PROFILE_DIR, { recursive: true });
+      await fs.writeFile(PROFILE_PATH, JSON.stringify(profile, null, 2), 'utf-8');
+    }
+    return NextResponse.json(profile);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const validation = validateMasterResume(body as MasterResume);
+  if (!validation.valid) {
+    return NextResponse.json(
+      { error: 'Invalid MasterResume', details: validation.errors },
+      { status: 400 },
+    );
+  }
+
+  try {
+    await fs.mkdir(PROFILE_DIR, { recursive: true });
+    await fs.writeFile(PROFILE_PATH, JSON.stringify(body, null, 2), 'utf-8');
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/tailor/route.ts
+++ b/src/app/api/tailor/route.ts
@@ -1,56 +1,63 @@
-import { NextRequest, NextResponse } from "next/server";
-import type { MasterResume, TailoredResume, ValidationResult } from "@/lib/types";
+import { NextRequest, NextResponse } from 'next/server';
+import path from 'path';
+import os from 'os';
+import type { PipelineResult } from '../../../lib/types';
+import { fetchJobDescription } from '../../../lib/pipeline/step2-fetch-jd';
+import { loadProfile } from '../../../lib/pipeline/step1-load-profile';
+import { tailorResume } from '../../../lib/pipeline/step4-tailor';
+import { renderPDF } from '../../../lib/pipeline/step5-render-pdf';
+import { validateResume } from '../../../lib/pipeline/step6-validate';
+import { fixResume } from '../../../lib/pipeline/step6b-fix';
 
-interface TailorRequest {
-  jobDescription: string;
+const PROFILE_PATH = path.join(os.homedir(), '.resume-app', 'profile.json');
+
+interface TailorRequestBody {
+  text?: string;
+  url?: string;
   targetPages: 1 | 2;
-  masterResume: MasterResume;
 }
 
-// Stub: real pipeline will be wired in a later issue.
 export async function POST(req: NextRequest) {
-  let body: TailorRequest;
+  let body: TailorRequestBody;
   try {
     body = await req.json();
   } catch {
-    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
   }
 
-  const { jobDescription, targetPages, masterResume } = body;
+  const { text, url, targetPages } = body;
 
-  if (!jobDescription?.trim()) {
-    return NextResponse.json({ error: "jobDescription is required." }, { status: 400 });
+  if (targetPages !== 1 && targetPages !== 2) {
+    return NextResponse.json({ error: 'targetPages must be 1 or 2' }, { status: 400 });
   }
-  if (!masterResume) {
-    return NextResponse.json({ error: "masterResume is required." }, { status: 400 });
+  if (!text && !url) {
+    return NextResponse.json({ error: 'Provide text or url' }, { status: 400 });
   }
 
-  // Stub: echo the master resume back as the tailored result.
-  // The real pipeline (tailor → validate → render PDF) will replace this.
-  const tailored: TailoredResume = {
-    jobTitle: "Role (stub)",
-    company: "Company (stub)",
-    jobDescription,
-    resume: masterResume,
-    tailoringNotes: `Stub response — pipeline not yet implemented. Target pages: ${targetPages}.`,
-    matchScore: 75,
-  };
+  try {
+    const jdText = url ? await fetchJobDescription(url) : text!;
+    const profile = await loadProfile(PROFILE_PATH);
+    let tailored = await tailorResume(profile, jdText);
+    let buffer = await renderPDF(tailored);
+    let validation = validateResume(tailored);
 
-  const validation: ValidationResult = {
-    valid: true,
-    errors: [],
-    warnings: ["This is a stub response. Real validation runs in the pipeline."],
-    score: 75,
-  };
+    if (!validation.valid) {
+      tailored = await fixResume(tailored, validation);
+      buffer = await renderPDF(tailored);
+      validation = validateResume(tailored);
+    }
 
-  // Return an empty PDF placeholder (1-byte stub).
-  const pdfBase64 = Buffer.from("%PDF-1.4 stub").toString("base64");
+    const result: Omit<PipelineResult, 'pdfBuffer'> & { pdfBase64: string } = {
+      success: true,
+      tailoredResume: tailored,
+      validation,
+      pdfBase64: buffer.toString('base64'),
+      steps: [],
+    };
 
-  return NextResponse.json({
-    tailored,
-    validation,
-    fixesApplied: [],
-    pages: targetPages,
-    pdfBase64,
-  });
+    return NextResponse.json(result);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
 }


### PR DESCRIPTION
Closes #4

## Summary
- **POST `/api/tailor`** — Full pipeline orchestration: fetch-jd → load-profile → build-prompt → tailor → render-pdf → validate → optional fix + re-render. Returns `PipelineResult` JSON with `pdfBase64` (buffer excluded from wire format).
- **POST `/api/fetch-jd`** — Thin wrapper around `fetchJd(url)`, returns `{ text }`.
- **GET `/api/profile`** — Reads `~/.resume-app/profile.json`, seeds from master-resume fixture on first run.
- **POST `/api/profile`** — Validates required `MasterResume` fields, writes to `~/.resume-app/profile.json`, returns `{ ok: true }`.

Pipeline step stubs (steps 1–4, 5, 6, 6b) are included with correct TypeScript signatures so routes compile cleanly today. Real implementations land with #2 (pipeline logic) and #3 (PDF rendering).

## Test plan
- [ ] `tsc --noEmit` passes with zero errors
- [ ] `npm test` — all 4 existing type tests pass
- [ ] After merge with #2 and #3: `POST /api/tailor` returns a valid `PipelineResult` with `pdfBase64`
- [ ] `POST /api/fetch-jd` with a valid URL returns `{ text }`
- [ ] `GET /api/profile` returns seeded `MasterResume` on first run
- [ ] `POST /api/profile` with invalid shape returns 400; valid shape writes file and returns `{ ok: true }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)