### PR TITLE
feat: change default dev port from 3000 to 3002

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pnpm dev
 bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3002](http://localhost:3002) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 3002",
     "build": "next build",
     "start": "next start",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- Updated `package.json` dev script to `next dev -p 3002`
- Updated README.md localhost URL from port 3000 to 3002

Closes #14

## Test plan
- [ ] Run `npm run dev` and verify server starts on port 3002
- [ ] Visit http://localhost:3002 to confirm the app loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)