### PR TITLE
feat: accept PDF upload as base resume input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@anthropic-ai/sdk": "^0.78.0",
         "@react-pdf/renderer": "^4.3.2",
         "next": "16.1.6",
+        "pdf-parse": "^2.4.5",
         "react": "19.2.3",
         "react-dom": "19.2.3"
       },
@@ -20,6 +21,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^20",
+        "@types/pdf-parse": "^1.1.5",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@typescript-eslint/eslint-plugin": "^8.56.1",
@@ -1813,6 +1815,190 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.80.tgz",
+      "integrity": "sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww==",
+      "license": "MIT",
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-x64": "0.1.80",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.80",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.80",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.80"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.80.tgz",
+      "integrity": "sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.80.tgz",
+      "integrity": "sha512-O64APRTXRUiAz0P8gErkfEr3lipLJgM6pjATwavZ22ebhjYl/SUbpgM0xcWPQBNMP1n29afAC/Us5PX1vg+JNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.80.tgz",
+      "integrity": "sha512-FqqSU7qFce0Cp3pwnTjVkKjjOtxMqRe6lmINxpIZYaZNnVI0H5FtsaraZJ36SiTHNjZlUB69/HhxNDT1Aaa9vA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.80.tgz",
+      "integrity": "sha512-eyWz0ddBDQc7/JbAtY4OtZ5SpK8tR4JsCYEZjCE3dI8pqoWUC8oMwYSBGCYfsx2w47cQgQCgMVRVTFiiO38hHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.80.tgz",
+      "integrity": "sha512-qwA63t8A86bnxhuA/GwOkK3jvb+XTQaTiVML0vAWoHyoZYTjNs7BzoOONDgTnNtr8/yHrq64XXzUoLqDzU+Uuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.80.tgz",
+      "integrity": "sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.80.tgz",
+      "integrity": "sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.80.tgz",
+      "integrity": "sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.80.tgz",
+      "integrity": "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.80.tgz",
+      "integrity": "sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -3030,6 +3216,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pdf-parse": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/pdf-parse/-/pdf-parse-1.1.5.tgz",
+      "integrity": "sha512-kBfrSXsloMnUJOKi25s3+hRmkycHfLK6A09eRGqF/N8BkQoPUmaCr+q8Cli5FnfohEz/rsv82zAiPz/LXtOGhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/react": {
@@ -7588,6 +7784,38 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pdf-parse": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-2.4.5.tgz",
+      "integrity": "sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@napi-rs/canvas": "0.1.80",
+        "pdfjs-dist": "5.4.296"
+      },
+      "bin": {
+        "pdf-parse": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.16.0 <21 || >=22.3.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/mehmet-kozan"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.4.296",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
+      "integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.80"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@anthropic-ai/sdk": "^0.78.0",
     "@react-pdf/renderer": "^4.3.2",
     "next": "16.1.6",
+    "pdf-parse": "^2.4.5",
     "react": "19.2.3",
     "react-dom": "19.2.3"
   },
@@ -24,6 +25,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^20",
+    "@types/pdf-parse": "^1.1.5",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@typescript-eslint/eslint-plugin": "^8.56.1",

--- a/src/app/api/resume/parse-pdf/route.ts
+++ b/src/app/api/resume/parse-pdf/route.ts
@@ -1,0 +1,126 @@
+import { NextRequest, NextResponse } from 'next/server';
+import Anthropic from '@anthropic-ai/sdk';
+import { PDFParse } from 'pdf-parse';
+
+export async function POST(req: NextRequest) {
+  const contentType = req.headers.get('content-type') ?? '';
+  if (!contentType.includes('multipart/form-data')) {
+    return NextResponse.json({ error: 'Expected multipart/form-data' }, { status: 400 });
+  }
+
+  let formData: FormData;
+  try {
+    formData = await req.formData();
+  } catch {
+    return NextResponse.json({ error: 'Failed to parse form data' }, { status: 400 });
+  }
+
+  const file = formData.get('file');
+  if (!(file instanceof Blob)) {
+    return NextResponse.json({ error: 'Missing "file" field' }, { status: 400 });
+  }
+
+  if (!file.type.includes('pdf')) {
+    return NextResponse.json({ error: 'File must be a PDF' }, { status: 400 });
+  }
+
+  // Extract text from PDF
+  let extractedText: string;
+  try {
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const parser = new PDFParse({ data: buffer });
+    const result = await parser.getText();
+    extractedText = result.text;
+    if (!extractedText.trim()) {
+      return NextResponse.json({ error: 'PDF appears to be empty or has no extractable text' }, { status: 422 });
+    }
+  } catch {
+    return NextResponse.json({ error: 'Failed to extract text from PDF' }, { status: 422 });
+  }
+
+  // Use Claude to convert extracted text into MasterResume schema
+  const anthropic = new Anthropic();
+
+  const prompt = `You are a resume parser. Extract the following resume text into a structured JSON object matching this TypeScript schema exactly:
+
+\`\`\`typescript
+interface MasterResume {
+  name: string;
+  email: string;
+  phone: string;
+  location: string;
+  linkedin?: string;
+  github?: string;
+  website?: string;
+  summary?: string;
+  experience: {
+    company: string;
+    title: string;
+    location: string;
+    startDate: string;   // format: "YYYY-MM"
+    endDate: string;     // format: "YYYY-MM" or "Present"
+    bullets: string[];
+  }[];
+  education: {
+    institution: string;
+    degree: string;
+    field: string;
+    graduationDate: string;  // format: "YYYY-MM"
+    gpa?: string;
+    honors?: string[];
+    relevantCoursework?: string[];
+  }[];
+  skills: {
+    category: string;
+    items: string[];
+  }[];
+  projects?: {
+    name: string;
+    description: string;
+    technologies: string[];
+    url?: string;
+    highlights?: string[];
+  }[];
+  leadership?: {
+    role: string;
+    organization: string;
+    period: string;
+    description?: string;
+  }[];
+}
+\`\`\`
+
+Rules:
+- Return ONLY valid JSON with no markdown fences, no explanation, no extra text.
+- All dates must be "YYYY-MM" format (e.g. "2022-06") or "Present".
+- If a field is not found in the resume text, omit optional fields. For required fields, use an empty string.
+- Group skills into logical categories (e.g. "Languages", "Frameworks", "Tools", "Cloud").
+- Preserve all bullet points from the experience section as-is.
+
+Resume text:
+${extractedText}`;
+
+  try {
+    const message = await anthropic.messages.create({
+      model: 'claude-opus-4-6',
+      max_tokens: 8192,
+      messages: [{ role: 'user', content: prompt }],
+    });
+
+    const content = message.content[0];
+    if (content.type !== 'text') {
+      return NextResponse.json({ error: 'Unexpected response from AI' }, { status: 500 });
+    }
+
+    // Strip any markdown fences if present
+    let jsonText = content.text.trim();
+    const fenceMatch = jsonText.match(/```(?:json)?\s*([\s\S]*?)```/);
+    if (fenceMatch) jsonText = fenceMatch[1].trim();
+
+    const masterResume = JSON.parse(jsonText);
+    return NextResponse.json({ resume: masterResume });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: `AI extraction failed: ${message}` }, { status: 500 });
+  }
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { MasterResume } from "@/lib/types";
 
 const STORAGE_KEY = "masterResume";
@@ -58,14 +58,24 @@ function validateResume(obj: unknown): string | null {
   return null;
 }
 
+type InputMode = "pdf" | "json";
+
 export default function ProfilePage() {
+  const [inputMode, setInputMode] = useState<InputMode>("pdf");
   const [json, setJson] = useState("");
   const [saved, setSaved] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
+  const [uploadState, setUploadState] = useState<"idle" | "parsing" | "done" | "error">("idle");
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [dragOver, setDragOver] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) setJson(stored);
+    if (stored) {
+      setJson(stored);
+      setInputMode("json");
+    }
   }, []);
 
   function handleSave() {
@@ -96,6 +106,54 @@ export default function ProfilePage() {
     setJson("");
     setValidationError(null);
     setSaved(false);
+    setUploadState("idle");
+    setUploadError(null);
+  }
+
+  async function handleFileUpload(file: File) {
+    if (!file.type.includes("pdf")) {
+      setUploadError("Please upload a PDF file.");
+      return;
+    }
+
+    setUploadState("parsing");
+    setUploadError(null);
+    setValidationError(null);
+
+    const formData = new FormData();
+    formData.append("file", file);
+
+    try {
+      const res = await fetch("/api/resume/parse-pdf", {
+        method: "POST",
+        body: formData,
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        throw new Error(data.error ?? `Request failed (${res.status})`);
+      }
+
+      setJson(JSON.stringify(data.resume, null, 2));
+      setUploadState("done");
+      setInputMode("json");
+    } catch (err) {
+      setUploadError(err instanceof Error ? err.message : "Failed to parse PDF.");
+      setUploadState("error");
+    }
+  }
+
+  function handleFileInputChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) handleFileUpload(file);
+  }
+
+  function handleDrop(e: React.DragEvent<HTMLDivElement>) {
+    e.preventDefault();
+    setDragOver(false);
+    const file = e.dataTransfer.files[0];
+    if (file) handleFileUpload(file);
   }
 
   const hasContent = json.trim().length > 0;
@@ -105,56 +163,137 @@ export default function ProfilePage() {
       <div>
         <h1 className="text-2xl font-semibold text-zinc-900">Master resume</h1>
         <p className="mt-1 text-sm text-zinc-500">
-          Paste your complete resume as JSON. This is used as the source for all
+          Upload your PDF resume or paste JSON directly. This is used as the source for all
           tailored versions.
         </p>
       </div>
 
-      <div className="rounded-lg border border-zinc-200 bg-white p-4 space-y-3">
-        <div className="flex items-center justify-between">
-          <label className="text-sm font-medium text-zinc-700">
-            Resume JSON
-          </label>
-          {hasContent && (
-            <button
-              onClick={handleClear}
-              className="text-xs text-zinc-400 hover:text-red-500 transition-colors"
-            >
-              Clear
-            </button>
-          )}
-        </div>
-
-        <textarea
-          value={json}
-          onChange={(e) => {
-            setJson(e.target.value);
-            setSaved(false);
-            setValidationError(null);
-          }}
-          placeholder={PLACEHOLDER}
-          rows={20}
-          spellCheck={false}
-          className="w-full rounded-lg border border-zinc-200 bg-zinc-50 px-4 py-3 font-mono text-xs text-zinc-900 placeholder-zinc-300 focus:border-zinc-400 focus:outline-none resize-y"
-        />
-
-        {validationError && (
-          <p className="text-sm text-red-600">{validationError}</p>
-        )}
-
-        <div className="flex items-center gap-3">
-          <button
-            onClick={handleSave}
-            disabled={!hasContent}
-            className="rounded-lg bg-zinc-900 px-5 py-2 text-sm font-medium text-white hover:bg-zinc-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-          >
-            Save profile
-          </button>
-          {saved && (
-            <span className="text-sm text-green-600 font-medium">Saved!</span>
-          )}
-        </div>
+      {/* Toggle */}
+      <div className="flex gap-1 rounded-lg bg-zinc-100 p-1 w-fit">
+        <button
+          onClick={() => setInputMode("pdf")}
+          className={`rounded-md px-4 py-1.5 text-sm font-medium transition-colors ${
+            inputMode === "pdf"
+              ? "bg-white text-zinc-900 shadow-sm"
+              : "text-zinc-500 hover:text-zinc-700"
+          }`}
+        >
+          Upload PDF
+        </button>
+        <button
+          onClick={() => setInputMode("json")}
+          className={`rounded-md px-4 py-1.5 text-sm font-medium transition-colors ${
+            inputMode === "json"
+              ? "bg-white text-zinc-900 shadow-sm"
+              : "text-zinc-500 hover:text-zinc-700"
+          }`}
+        >
+          Paste JSON
+        </button>
       </div>
+
+      {/* PDF Upload Panel */}
+      {inputMode === "pdf" && (
+        <div className="rounded-lg border border-zinc-200 bg-white p-6">
+          <div
+            onDrop={handleDrop}
+            onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
+            onDragLeave={() => setDragOver(false)}
+            onClick={() => fileInputRef.current?.click()}
+            className={`flex flex-col items-center justify-center gap-3 rounded-lg border-2 border-dashed px-6 py-12 cursor-pointer transition-colors ${
+              dragOver
+                ? "border-zinc-400 bg-zinc-50"
+                : "border-zinc-200 hover:border-zinc-300 hover:bg-zinc-50"
+            }`}
+          >
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".pdf,application/pdf"
+              onChange={handleFileInputChange}
+              className="hidden"
+            />
+            {uploadState === "parsing" ? (
+              <div className="flex flex-col items-center gap-2">
+                <div className="h-6 w-6 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-700" />
+                <p className="text-sm text-zinc-500">Extracting and parsing resume...</p>
+              </div>
+            ) : (
+              <>
+                <svg className="h-10 w-10 text-zinc-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
+                </svg>
+                <div className="text-center">
+                  <p className="text-sm font-medium text-zinc-700">Drop your PDF here or click to browse</p>
+                  <p className="mt-1 text-xs text-zinc-400">PDF files only</p>
+                </div>
+              </>
+            )}
+          </div>
+
+          {uploadError && (
+            <p className="mt-3 text-sm text-red-600">{uploadError}</p>
+          )}
+
+          {uploadState === "done" && (
+            <p className="mt-3 text-sm text-green-600 font-medium">
+              Resume parsed successfully. Review the JSON below and save.
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* JSON Editor Panel */}
+      {inputMode === "json" && (
+        <div className="rounded-lg border border-zinc-200 bg-white p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <label className="text-sm font-medium text-zinc-700">
+              Resume JSON
+              {uploadState === "done" && (
+                <span className="ml-2 text-xs font-normal text-zinc-400">(parsed from PDF — review before saving)</span>
+              )}
+            </label>
+            {hasContent && (
+              <button
+                onClick={handleClear}
+                className="text-xs text-zinc-400 hover:text-red-500 transition-colors"
+              >
+                Clear
+              </button>
+            )}
+          </div>
+
+          <textarea
+            value={json}
+            onChange={(e) => {
+              setJson(e.target.value);
+              setSaved(false);
+              setValidationError(null);
+            }}
+            placeholder={PLACEHOLDER}
+            rows={20}
+            spellCheck={false}
+            className="w-full rounded-lg border border-zinc-200 bg-zinc-50 px-4 py-3 font-mono text-xs text-zinc-900 placeholder-zinc-300 focus:border-zinc-400 focus:outline-none resize-y"
+          />
+
+          {validationError && (
+            <p className="text-sm text-red-600">{validationError}</p>
+          )}
+
+          <div className="flex items-center gap-3">
+            <button
+              onClick={handleSave}
+              disabled={!hasContent}
+              className="rounded-lg bg-zinc-900 px-5 py-2 text-sm font-medium text-white hover:bg-zinc-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            >
+              Save profile
+            </button>
+            {saved && (
+              <span className="text-sm text-green-600 font-medium">Saved!</span>
+            )}
+          </div>
+        </div>
+      )}
 
       <details className="text-sm text-zinc-500">
         <summary className="cursor-pointer hover:text-zinc-700">


### PR DESCRIPTION
## Summary

- Adds `POST /api/resume/parse-pdf` — accepts a multipart PDF upload, extracts text with `pdf-parse`, then calls Claude to map the extracted text to the `MasterResume` JSON schema
- Updates the `/profile` page with an **Upload PDF / Paste JSON** toggle:
  - PDF mode: drag-and-drop or file picker, spinner while parsing, auto-populates the JSON editor on success
  - JSON mode: existing textarea flow — unchanged and still fully functional as a fallback
- Graceful error handling for bad file type, extraction failures, and AI parse errors

## Test plan

- [ ] Upload a real PDF resume → JSON editor populates with structured data
- [ ] Edit the pre-populated JSON before saving → changes preserved
- [ ] Save the profile → works the same as the manual JSON path
- [ ] Upload a non-PDF file → error message shown
- [ ] Switch to "Paste JSON" tab → existing textarea flow still works
- [ ] Clear button resets both tabs and localStorage

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)