### PR TITLE
feat: add E2E browser tests with Playwright and mocked API

### DIFF
--- a/e2e/fixtures/master-resume.json
+++ b/e2e/fixtures/master-resume.json
@@ -1,0 +1,35 @@
+{
+  "name": "Jane Doe",
+  "email": "jane.doe@example.com",
+  "phone": "+1 (555) 123-4567",
+  "location": "San Francisco, CA",
+  "linkedin": "https://linkedin.com/in/janedoe",
+  "github": "https://github.com/janedoe",
+  "summary": "Experienced software engineer with 8+ years building scalable distributed systems.",
+  "experience": [
+    {
+      "company": "Acme Corp",
+      "title": "Senior Software Engineer",
+      "location": "San Francisco, CA",
+      "startDate": "2021-03",
+      "endDate": "Present",
+      "bullets": [
+        "Led migration of monolithic service to microservices, reducing p99 latency by 40%",
+        "Mentored 4 junior engineers through weekly 1:1s and code reviews"
+      ]
+    }
+  ],
+  "education": [
+    {
+      "institution": "State University",
+      "degree": "Bachelor of Science",
+      "field": "Computer Science",
+      "graduationDate": "2016-05",
+      "gpa": "3.8"
+    }
+  ],
+  "skills": [
+    { "category": "Languages", "items": ["TypeScript", "Python", "Go"] },
+    { "category": "Frameworks", "items": ["React", "Next.js", "Node.js"] }
+  ]
+}

--- a/e2e/fixtures/tailor-response.json
+++ b/e2e/fixtures/tailor-response.json
@@ -1,0 +1,53 @@
+{
+  "tailored": {
+    "jobTitle": "Senior Software Engineer",
+    "company": "Acme Corp",
+    "jobDescription": "We are looking for a Senior Software Engineer to join our team.",
+    "resume": {
+      "name": "Jane Doe",
+      "email": "jane.doe@example.com",
+      "phone": "+1 (555) 123-4567",
+      "location": "San Francisco, CA",
+      "linkedin": "https://linkedin.com/in/janedoe",
+      "github": "https://github.com/janedoe",
+      "summary": "Experienced software engineer with 8+ years building scalable distributed systems.",
+      "experience": [
+        {
+          "company": "Acme Corp",
+          "title": "Senior Software Engineer",
+          "location": "San Francisco, CA",
+          "startDate": "2021-03",
+          "endDate": "Present",
+          "bullets": [
+            "Led migration of monolithic service to microservices, reducing p99 latency by 40%",
+            "Mentored 4 junior engineers through weekly 1:1s and code reviews"
+          ]
+        }
+      ],
+      "education": [
+        {
+          "institution": "State University",
+          "degree": "Bachelor of Science",
+          "field": "Computer Science",
+          "graduationDate": "2016-05",
+          "gpa": "3.8"
+        }
+      ],
+      "skills": [
+        { "category": "Languages", "items": ["TypeScript", "Python", "Go"] },
+        { "category": "Frameworks", "items": ["React", "Next.js", "Node.js"] }
+      ]
+    },
+    "tailoringNotes": "Highlighted distributed systems experience to match role requirements.",
+    "matchScore": 88
+  },
+  "validation": {
+    "valid": true,
+    "errors": [],
+    "warnings": [],
+    "score": 88
+  },
+  "fixesApplied": [],
+  "pages": 1,
+  "pdfBase64": "JVBERi0xLjQKMSAwIG9iajw8L1R5cGUvQ2F0YWxvZy9QYWdlcyAyIDAgUj4+ZW5kb2JqCjIgMCBvYmo8PC9UeXBlL1BhZ2VzL0tpZHNbMyAwIFJdL0NvdW50IDE+PmVuZG9iagozIDAgb2JqPDwvVHlwZS9QYWdlL01lZGlhQm94WzAgMCA2MTIgNzkyXS9QYXJlbnQgMiAwIFIvUmVzb3VyY2VzPDw+Pj4+ZW5kb2JqCnhyZWYKMCA0CjAwMDAwMDAwMDAgNjU1MzUgZgowMDAwMDAwMDA5IDAwMDAwIG4KMDAwMDAwMDA1OCAwMDAwMCBuCjAwMDAwMDAxMTUgMDAwMDAgbgp0cmFpbGVyPDwvUm9vdCAxIDAgUi9TaXplIDQ+PgpzdGFydHhyZWYKMTkwCiUlRU9G"
+}

--- a/e2e/generate.spec.ts
+++ b/e2e/generate.spec.ts
@@ -1,0 +1,119 @@
+import { test, expect } from "@playwright/test";
+import { GeneratePage } from "./pages/generate.page";
+import { ProfilePage } from "./pages/profile.page";
+import masterResume from "./fixtures/master-resume.json";
+import tailorFixture from "./fixtures/tailor-response.json";
+
+const VALID_RESUME_JSON = JSON.stringify(masterResume, null, 2);
+const SAMPLE_JD = "We are looking for a Senior Software Engineer to join our team. You will build scalable backend services using TypeScript and Node.js.";
+
+async function saveProfile(page: import("@playwright/test").Page) {
+  const profile = new ProfilePage(page);
+  await profile.goto();
+  await profile.pasteResume(VALID_RESUME_JSON);
+  await profile.save();
+}
+
+test.describe("Generate page", () => {
+  test("shows error when no profile is saved", async ({ page }) => {
+    // Clear any existing profile
+    await page.goto("/");
+    await page.evaluate(() => localStorage.removeItem("masterResume"));
+
+    const generate = new GeneratePage(page);
+    await generate.goto();
+    await generate.pasteJobDescription(SAMPLE_JD);
+    await page.getByRole("button", { name: "Generate" }).click();
+
+    await expect(
+      page.locator('[class*="bg-red-50"], [class*="border-red-200"]').first()
+    ).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText(/No master resume found/i)).toBeVisible();
+  });
+
+  test("generates tailored resume from pasted job description", async ({ page }) => {
+    await saveProfile(page);
+
+    const generate = new GeneratePage(page);
+    await generate.mockTailorApi();
+    await generate.goto();
+    await generate.pasteJobDescription(SAMPLE_JD);
+    await generate.generate();
+
+    await expect(page.getByRole("button", { name: "Download PDF" })).toBeVisible();
+  });
+
+  test("shows pipeline steps during generation", async ({ page }) => {
+    await saveProfile(page);
+
+    // Use a slow route so we can see loading state
+    await page.route("/api/tailor", async (route) => {
+      await new Promise((r) => setTimeout(r, 500));
+      await route.fulfill({ json: tailorFixture });
+    });
+
+    const generate = new GeneratePage(page);
+    await generate.goto();
+    await generate.pasteJobDescription(SAMPLE_JD);
+    await page.getByRole("button", { name: "Generate" }).click();
+
+    // Pipeline status should appear while loading
+    await expect(page.getByText("Parse job description")).toBeVisible();
+
+    // Wait for completion
+    await expect(page.getByRole("button", { name: "Download PDF" })).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("displays validation score after completion", async ({ page }) => {
+    await saveProfile(page);
+
+    const generate = new GeneratePage(page);
+    await generate.mockTailorApi();
+    await generate.goto();
+    await generate.pasteJobDescription(SAMPLE_JD);
+    await generate.generate();
+
+    const score = await generate.getValidationScore();
+    expect(score).toBe(tailorFixture.validation.score);
+  });
+
+  test("downloads PDF file when Download PDF is clicked", async ({ page }) => {
+    await saveProfile(page);
+
+    const generate = new GeneratePage(page);
+    await generate.mockTailorApi();
+    await generate.goto();
+    await generate.pasteJobDescription(SAMPLE_JD);
+    await generate.generate();
+
+    const download = await generate.downloadPdf();
+    expect(download.suggestedFilename()).toMatch(/\.pdf$/);
+  });
+
+  test("full E2E flow: save profile → enter JD → generate → download PDF", async ({ page }) => {
+    // 1. Save profile
+    const profile = new ProfilePage(page);
+    await profile.goto();
+    await profile.pasteResume(VALID_RESUME_JSON);
+    await profile.save();
+    await expect(page.getByText("Saved!")).toBeVisible();
+
+    // 2. Navigate to generate page and mock API
+    const generate = new GeneratePage(page);
+    await generate.mockTailorApi();
+    await generate.goto();
+
+    // 3. Enter job description and generate
+    await generate.pasteJobDescription(SAMPLE_JD);
+    await generate.selectPages(1);
+    await generate.generate();
+
+    // 4. Verify result shows up
+    await expect(page.getByRole("button", { name: "Download PDF" })).toBeVisible();
+    await expect(page.getByText("Valid", { exact: true })).toBeVisible();
+
+    // 5. Download the PDF
+    const download = await generate.downloadPdf();
+    expect(download.suggestedFilename()).toMatch(/resume.*\.pdf$/);
+  });
+});

--- a/e2e/pages/generate.page.ts
+++ b/e2e/pages/generate.page.ts
@@ -1,0 +1,54 @@
+import { type Page } from "@playwright/test";
+import tailorFixture from "../fixtures/tailor-response.json";
+
+export class GeneratePage {
+  constructor(private page: Page) {}
+
+  async goto() {
+    await this.page.goto("/");
+  }
+
+  async mockTailorApi() {
+    await this.page.route("/api/tailor", async (route) => {
+      await route.fulfill({ json: tailorFixture });
+    });
+  }
+
+  async pasteJobDescription(text: string) {
+    await this.page.getByRole("button", { name: "Paste text" }).click();
+    await this.page.locator("textarea").fill(text);
+  }
+
+  async selectPages(n: 1 | 2) {
+    await this.page.locator(`input[type="radio"][value="${n}"]`).check();
+  }
+
+  async generate() {
+    await this.page.getByRole("button", { name: "Generate" }).click();
+    // Wait for either result or error to appear
+    await this.page
+      .locator('[class*="bg-red-50"], button:has-text("Download PDF")')
+      .waitFor({ state: "visible", timeout: 15_000 });
+  }
+
+  async downloadPdf() {
+    const [download] = await Promise.all([
+      this.page.waitForEvent("download"),
+      this.page.getByRole("button", { name: "Download PDF" }).click(),
+    ]);
+    return download;
+  }
+
+  async getValidationScore() {
+    const text = await this.page
+      .locator("span")
+      .filter({ hasText: /^\d+\/100$/ })
+      .first()
+      .textContent();
+    return text ? parseInt(text.split("/")[0], 10) : null;
+  }
+
+  async getErrorText() {
+    return this.page.locator('[class*="bg-red-50"]').textContent();
+  }
+}

--- a/e2e/pages/profile.page.ts
+++ b/e2e/pages/profile.page.ts
@@ -1,0 +1,30 @@
+import { type Page } from "@playwright/test";
+
+export class ProfilePage {
+  constructor(private page: Page) {}
+
+  async goto() {
+    await this.page.goto("/profile");
+  }
+
+  async pasteResume(json: string) {
+    await this.page.locator("textarea").fill(json);
+  }
+
+  async save() {
+    await this.page.getByRole("button", { name: "Save profile" }).click();
+    await this.page.getByText("Saved!").waitFor({ state: "visible" });
+  }
+
+  async clear() {
+    await this.page.getByRole("button", { name: "Clear" }).click();
+  }
+
+  async getSavedMessage() {
+    return this.page.getByText("Saved!").textContent();
+  }
+
+  async getValidationError() {
+    return this.page.locator("p.text-red-600").textContent();
+  }
+}

--- a/e2e/profile.spec.ts
+++ b/e2e/profile.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from "@playwright/test";
+import { ProfilePage } from "./pages/profile.page";
+import masterResume from "./fixtures/master-resume.json";
+
+const VALID_JSON = JSON.stringify(masterResume, null, 2);
+
+test.describe("Profile page", () => {
+  test("saves a valid master resume JSON", async ({ page }) => {
+    const profile = new ProfilePage(page);
+    await profile.goto();
+    await profile.pasteResume(VALID_JSON);
+    await profile.save();
+    await expect(page.getByText("Saved!")).toBeVisible();
+  });
+
+  test("shows validation error for invalid JSON", async ({ page }) => {
+    const profile = new ProfilePage(page);
+    await profile.goto();
+    await profile.pasteResume("{ not valid json }");
+    await page.getByRole("button", { name: "Save profile" }).click();
+    await expect(page.locator("p.text-red-600")).toBeVisible();
+    await expect(page.locator("p.text-red-600")).toContainText("Invalid JSON");
+  });
+
+  test("shows validation error for missing required field", async ({ page }) => {
+    const profile = new ProfilePage(page);
+    await profile.goto();
+    const missingName = { ...masterResume };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (missingName as any).name;
+    await profile.pasteResume(JSON.stringify(missingName));
+    await page.getByRole("button", { name: "Save profile" }).click();
+    await expect(page.locator("p.text-red-600")).toBeVisible();
+    await expect(page.locator("p.text-red-600")).toContainText("name");
+  });
+
+  test("clears saved resume on Clear", async ({ page }) => {
+    const profile = new ProfilePage(page);
+    await profile.goto();
+    await profile.pasteResume(VALID_JSON);
+    await profile.save();
+    await profile.clear();
+    await expect(page.locator("textarea")).toHaveValue("");
+  });
+
+  test("persists resume in localStorage after page reload", async ({ page }) => {
+    const profile = new ProfilePage(page);
+    await profile.goto();
+    await profile.pasteResume(VALID_JSON);
+    await profile.save();
+
+    // Reload and verify content is still there
+    await page.reload();
+    await expect(page.locator("textarea")).not.toHaveValue("");
+
+    // Verify localStorage contains the saved resume
+    const stored = await page.evaluate(() =>
+      localStorage.getItem("masterResume")
+    );
+    expect(stored).not.toBeNull();
+    const parsed = JSON.parse(stored!);
+    expect(parsed.name).toBe(masterResume.name);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.4",
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -2016,6 +2017,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@react-pdf/fns": {
@@ -7606,6 +7623,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint src --ext .ts,.tsx",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
@@ -20,6 +23,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.4",
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  retries: 1,
+  use: {
+    baseURL: "http://localhost:3002",
+    trace: "on-first-retry",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:3002",
+    reuseExistingServer: true,
+    timeout: 30_000,
+  },
+});


### PR DESCRIPTION
## Summary

- Adds Playwright E2E test suite with 11 tests across profile and generate pages
- Mocks `/api/tailor` at the browser network level using `page.route()` — no Claude API calls during tests
- Uses Page Object Models for clean, maintainable test code
- Dev server auto-starts on port 3002 (reuses existing if running)

## Files added

| File | Purpose |
|------|---------|
| `playwright.config.ts` | Chromium config, webServer auto-start |
| `e2e/fixtures/master-resume.json` | Valid `MasterResume` fixture |
| `e2e/fixtures/tailor-response.json` | Pre-baked `/api/tailor` response with minimal PDF |
| `e2e/pages/profile.page.ts` | Page Object for `/profile` |
| `e2e/pages/generate.page.ts` | Page Object for `/` (generate page) |
| `e2e/profile.spec.ts` | 5 profile page tests |
| `e2e/generate.spec.ts` | 6 generate page tests incl. full E2E flow |

## Test plan

- [x] `npm run test:e2e` — all 11 tests pass headlessly (6.2s)
- [x] Profile: save valid JSON, invalid JSON error, missing field error, clear, localStorage persistence
- [x] Generate: no-profile error, generate with mock, pipeline steps visible, validation score, PDF download, full E2E flow

## Scripts added

```json
"test:e2e": "playwright test",
"test:e2e:ui": "playwright test --ui",
"test:e2e:headed": "playwright test --headed"
```

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)