### PR TITLE
fix: profile storage disconnect — call POST /api/profile on save and handle missing profile in tailor

### DIFF
--- a/src/app/api/tailor/route.ts
+++ b/src/app/api/tailor/route.ts
@@ -36,7 +36,19 @@ export async function POST(req: NextRequest) {
 
   try {
     const jdText = url ? await fetchJobDescription(url) : text!;
-    const profile = await loadProfile(PROFILE_PATH);
+    let profile;
+    try {
+      profile = await loadProfile(PROFILE_PATH);
+    } catch (err) {
+      const isNotFound = err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT';
+      if (isNotFound) {
+        return NextResponse.json(
+          { error: 'No profile found. Please visit /profile to set up your master resume before generating.' },
+          { status: 404 },
+        );
+      }
+      throw err;
+    }
     let tailored = await tailorResume(profile, jdText);
     let buffer = await renderPDF(tailored);
     let validation = validateResume(tailored);

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -78,7 +78,7 @@ export default function ProfilePage() {
     }
   }, []);
 
-  function handleSave() {
+  async function handleSave() {
     setSaved(false);
     setValidationError(null);
 
@@ -97,6 +97,23 @@ export default function ProfilePage() {
     }
 
     localStorage.setItem(STORAGE_KEY, json);
+
+    try {
+      const res = await fetch("/api/profile", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: json,
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setValidationError(data.error ?? `Failed to save profile (${res.status})`);
+        return;
+      }
+    } catch {
+      setValidationError("Network error — could not save profile to server.");
+      return;
+    }
+
     setSaved(true);
     setTimeout(() => setSaved(false), 3000);
   }


### PR DESCRIPTION
## Summary

- **`src/app/profile/page.tsx`**: `handleSave()` now calls `POST /api/profile` after writing to localStorage, so the profile is persisted to disk (`~/.resume-app/profile.json`) where the tailor pipeline expects it.
- **`src/app/api/tailor/route.ts`**: Catches `ENOENT` from `loadProfile` and returns a clear 404 with a message directing users to `/profile`, instead of a cryptic 500.

Closes #23

## Test plan

- [ ] Go to `/profile`, paste valid resume JSON, click Save — verify no error and profile is written to `~/.resume-app/profile.json`
- [ ] Go to `/generate`, submit a job description — verify resume generates successfully
- [ ] Delete `~/.resume-app/profile.json`, call `POST /api/tailor` — verify a 404 with a helpful message is returned instead of ENOENT 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)