### PR TITLE
fix: align /api/tailor response shape with frontend TailorResponse interface

### DIFF
--- a/src/app/api/tailor/route.ts
+++ b/src/app/api/tailor/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import path from 'path';
 import os from 'os';
-import type { PipelineResult } from '../../../lib/types';
 import { fetchJobDescription } from '../../../lib/pipeline/step2-fetch-jd';
 import { loadProfile } from '../../../lib/pipeline/step1-load-profile';
 import { tailorResume } from '../../../lib/pipeline/step4-tailor';
@@ -38,24 +37,26 @@ export async function POST(req: NextRequest) {
     const jdText = url ? await fetchJobDescription(url) : text!;
     const profile = await loadProfile(PROFILE_PATH);
     let tailored = await tailorResume(profile, jdText);
-    let buffer = await renderPDF(tailored);
+    let { buffer, pages } = await renderPDF(tailored);
     let validation = validateResume(tailored);
+    let fixesApplied: string[] = [];
 
     if (!validation.valid) {
-      tailored = await fixResume(tailored, validation);
-      buffer = await renderPDF(tailored);
+      const fixed = await fixResume(tailored, validation);
+      tailored = fixed.tailored;
+      fixesApplied = fixed.fixesApplied;
+      ({ buffer, pages } = await renderPDF(tailored));
       validation = validateResume(tailored);
     }
 
-    const result: Omit<PipelineResult, 'pdfBuffer'> & { pdfBase64: string } = {
+    return NextResponse.json({
       success: true,
-      tailoredResume: tailored,
+      tailored,
       validation,
+      fixesApplied,
+      pages,
       pdfBase64: buffer.toString('base64'),
-      steps: [],
-    };
-
-    return NextResponse.json(result);
+    });
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
     return NextResponse.json({ error: message }, { status: 500 });

--- a/src/lib/pipeline/__tests__/step6b-fix.test.ts
+++ b/src/lib/pipeline/__tests__/step6b-fix.test.ts
@@ -32,7 +32,7 @@ describe("step6b-fix", () => {
     const mockClient = makeMockClient(JSON.stringify(fixed));
 
     const result = await fixResume(tailored, failingValidation, mockClient);
-    expect(result.resume.summary).toBe("Fixed summary.");
+    expect(result.tailored.resume.summary).toBe("Fixed summary.");
   });
 
   it("handles JSON wrapped in markdown code fences", async () => {
@@ -44,7 +44,20 @@ describe("step6b-fix", () => {
     const mockClient = makeMockClient(fenced);
 
     const result = await fixResume(tailored, failingValidation, mockClient);
-    expect(result.resume.summary).toBe("Fixed summary.");
+    expect(result.tailored.resume.summary).toBe("Fixed summary.");
+  });
+
+  it("returns fixesApplied populated from validation errors and warnings", async () => {
+    const mockClient = makeMockClient(JSON.stringify(tailored));
+    const validation: ValidationResult = {
+      valid: false,
+      errors: ["Missing jobTitle"],
+      warnings: ["resume.summary is missing"],
+      score: 30,
+    };
+
+    const result = await fixResume(tailored, validation, mockClient);
+    expect(result.fixesApplied).toEqual(["Missing jobTitle", "resume.summary is missing"]);
   });
 
   it("throws when Claude returns no JSON", async () => {

--- a/src/lib/pipeline/step5-render-pdf.ts
+++ b/src/lib/pipeline/step5-render-pdf.ts
@@ -4,9 +4,12 @@ import type { DocumentProps } from "@react-pdf/renderer";
 import { ResumePDF } from "@/components/ResumePDF";
 import type { TailoredResume } from "@/lib/types";
 
-export async function renderPDF(tailoredResume: TailoredResume): Promise<Buffer> {
+export async function renderPDF(tailoredResume: TailoredResume): Promise<{ buffer: Buffer; pages: number }> {
   // ResumePDF renders a Document at its root, so the cast to DocumentProps is safe.
   const element = createElement(ResumePDF, { tailoredResume }) as ReactElement<DocumentProps>;
-  const buffer = await renderToBuffer(element);
-  return Buffer.from(buffer);
+  const raw = await renderToBuffer(element);
+  const buffer = Buffer.from(raw);
+  // Count individual page objects in the PDF binary (excludes /Pages parent nodes)
+  const pages = (buffer.toString("binary").match(/\/Type\s*\/Page[^s]/g) ?? []).length || 1;
+  return { buffer, pages };
 }

--- a/src/lib/pipeline/step6b-fix.ts
+++ b/src/lib/pipeline/step6b-fix.ts
@@ -5,7 +5,7 @@ export async function fixResume(
   tailored: TailoredResume,
   validation: ValidationResult,
   client?: Anthropic
-): Promise<TailoredResume> {
+): Promise<{ tailored: TailoredResume; fixesApplied: string[] }> {
   const anthropic = client ?? new Anthropic();
 
   const errorLines = validation.errors.map((e) => `- ${e}`).join("\n");
@@ -39,13 +39,17 @@ ${warningLines || "(none)"}
   }
 
   const text = content.text;
+  const fixesApplied = [...validation.errors, ...validation.warnings];
+
   const fenceMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/);
-  if (fenceMatch) return JSON.parse(fenceMatch[1].trim()) as TailoredResume;
+  if (fenceMatch) {
+    return { tailored: JSON.parse(fenceMatch[1].trim()) as TailoredResume, fixesApplied };
+  }
 
   const start = text.indexOf("{");
   const end = text.lastIndexOf("}");
   if (start === -1 || end === -1) {
     throw new Error("No JSON found in fix response");
   }
-  return JSON.parse(text.slice(start, end + 1)) as TailoredResume;
+  return { tailored: JSON.parse(text.slice(start, end + 1)) as TailoredResume, fixesApplied };
 }


### PR DESCRIPTION
## Summary

- Renames `tailoredResume` → `tailored` in the API response to match what the frontend expects
- Returns an actual `pages` count by parsing the rendered PDF buffer in `renderPDF()`
- Populates `fixesApplied` with the list of validation errors/warnings that were fixed by `fixResume()`

## Changes

- **`src/app/api/tailor/route.ts`**: Build response with `tailored`, `pages`, `fixesApplied` keys; remove unused `PipelineResult` import and `steps: []`
- **`src/lib/pipeline/step5-render-pdf.ts`**: Return `{ buffer, pages }` instead of `Buffer`; count pages by scanning PDF binary for `/Type /Page` objects
- **`src/lib/pipeline/step6b-fix.ts`**: Return `{ tailored, fixesApplied }` instead of `TailoredResume`; populate `fixesApplied` from validation errors and warnings
- **`src/lib/pipeline/__tests__/step6b-fix.test.ts`**: Update assertions for new return shape; add test covering `fixesApplied` population

## Test plan

- [x] All 77 unit tests pass (`npm test`)
- [x] TypeScript compilation clean (`tsc --noEmit`)
- [ ] Manually verify the generate page renders page count and fixes applied sections

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)