### PR TITLE
feat: add integration tests that hit real API routes

### DIFF
--- a/e2e/integration.spec.ts
+++ b/e2e/integration.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from "@playwright/test";
+import { promises as fs } from "fs";
+import path from "path";
+import os from "os";
+import masterResume from "./fixtures/master-resume.json";
+
+const BASE_URL = "http://localhost:3002";
+const PROFILE_PATH = path.join(os.homedir(), ".resume-app", "profile.json");
+
+test.describe("API integration", () => {
+  test("profile round-trip: POST then GET returns same data", async ({ request }) => {
+    const postRes = await request.post(`${BASE_URL}/api/profile`, {
+      data: masterResume,
+    });
+    expect(postRes.status()).toBe(200);
+    expect(await postRes.json()).toEqual({ ok: true });
+
+    const getRes = await request.get(`${BASE_URL}/api/profile`);
+    expect(getRes.status()).toBe(200);
+    const profile = await getRes.json();
+    expect(profile.name).toBe(masterResume.name);
+    expect(profile.email).toBe(masterResume.email);
+    expect(profile.experience).toEqual(masterResume.experience);
+  });
+
+  test("tailor returns 400 when targetPages is missing", async ({ request }) => {
+    const res = await request.post(`${BASE_URL}/api/tailor`, {
+      data: { text: "Looking for a Senior Software Engineer" },
+    });
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/targetPages/);
+  });
+
+  test("tailor returns 400 when neither text nor url is provided", async ({ request }) => {
+    const res = await request.post(`${BASE_URL}/api/tailor`, {
+      data: { jobDescription: "Looking for a Senior Software Engineer", targetPages: 1 },
+    });
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/text or url/i);
+  });
+
+  test("tailor returns helpful error when no profile exists on disk", async ({ request }) => {
+    const backupPath = `${PROFILE_PATH}.bak`;
+    let hadProfile = false;
+    try {
+      await fs.rename(PROFILE_PATH, backupPath);
+      hadProfile = true;
+    } catch {
+      // profile didn't exist on disk — that's the condition we want
+    }
+
+    try {
+      const res = await request.post(`${BASE_URL}/api/tailor`, {
+        data: { text: "Looking for a Senior Software Engineer", targetPages: 1 },
+      });
+      expect(res.status()).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBeTruthy();
+    } finally {
+      if (hadProfile) {
+        await fs.rename(backupPath, PROFILE_PATH);
+      }
+    }
+  });
+
+  test("fetch-jd returns 400 when url field is missing", async ({ request }) => {
+    const res = await request.post(`${BASE_URL}/api/fetch-jd`, {
+      data: { notUrl: "https://example.com" },
+    });
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/url/i);
+  });
+
+  test("fetch-jd returns text field for a valid URL", async ({ request }) => {
+    const res = await request.post(`${BASE_URL}/api/fetch-jd`, {
+      data: { url: "https://example.com" },
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(typeof body.text).toBe("string");
+    expect(body.text.length).toBeGreaterThan(0);
+  });
+});

--- a/e2e/pages/generate.page.ts
+++ b/e2e/pages/generate.page.ts
@@ -15,6 +15,10 @@ export class GeneratePage {
         await route.fulfill({ status: 400, json: { error: "Provide text or url" } });
         return;
       }
+      if (body.targetPages !== 1 && body.targetPages !== 2) {
+        await route.fulfill({ status: 400, json: { error: "targetPages must be 1 or 2" } });
+        return;
+      }
       await route.fulfill({ json: tailorFixture });
     });
   }


### PR DESCRIPTION
## Summary

- Add `e2e/integration.spec.ts` with 6 tests that call real Next.js API routes (no mocking via `page.route()`)
- Extend `mockTailorApi()` in `e2e/pages/generate.page.ts` to also validate `targetPages` matches the real API contract

## What the integration tests cover

| Test | Route | Assert |
|------|-------|--------|
| Profile round-trip | `POST /api/profile` → `GET /api/profile` | GET returns same data that was POSTed |
| Tailor missing `targetPages` | `POST /api/tailor` | 400 with `targetPages` in error message |
| Tailor wrong field name (`jobDescription` instead of `text`) | `POST /api/tailor` | 400 with "text or url" message |
| Tailor with no profile on disk | `POST /api/tailor` | 500 with a non-empty error message |
| Fetch-JD missing `url` field | `POST /api/fetch-jd` | 400 with "url" in error message |
| Fetch-JD with valid URL | `POST /api/fetch-jd` | 200 with `{ text: string }` response |

## Test plan

- [ ] Run `npm run test:e2e -- e2e/integration.spec.ts` against the dev server on port 3002
- [ ] Verify existing E2E tests (`generate.spec.ts`, `profile.spec.ts`) still pass — the `targetPages` mock update only adds a new check and the existing tests call `selectPages(1)` which sets `targetPages: 1` correctly

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)