### PR TITLE
feat: add structured logging to pipeline steps

### DIFF
--- a/src/app/api/tailor/route.ts
+++ b/src/app/api/tailor/route.ts
@@ -35,6 +35,10 @@ export async function POST(req: NextRequest) {
 
   try {
     const jdText = url ? await fetchJobDescription(url) : text!;
+    console.log(
+      `[tailor] request start: method=POST targetPages=${targetPages} jdLength=${jdText.length}`
+    );
+
     let profile;
     try {
       profile = await loadProfile(PROFILE_PATH);
@@ -48,18 +52,46 @@ export async function POST(req: NextRequest) {
       }
       throw err;
     }
+
+    console.log('[tailor] step4: start');
+    let t = Date.now();
     let tailored = await tailorResume(profile, jdText);
+    console.log(`[tailor] step4: done in ${Date.now() - t}ms`);
+
+    console.log('[tailor] step5: start');
+    t = Date.now();
     let { buffer, pages } = await renderPDF(tailored);
+    console.log(`[tailor] step5: done in ${Date.now() - t}ms`);
+
+    console.log('[tailor] step6: start');
+    t = Date.now();
     let validation = validateResume(tailored);
+    console.log(`[tailor] step6: done in ${Date.now() - t}ms`);
+
     let fixesApplied: string[] = [];
 
     if (!validation.valid) {
+      console.log('[tailor] step6b: start (validation failed, attempting fix)');
+      t = Date.now();
       const fixed = await fixResume(tailored, validation);
       tailored = fixed.tailored;
       fixesApplied = fixed.fixesApplied;
+      console.log(`[tailor] step6b: done in ${Date.now() - t}ms`);
+
+      console.log('[tailor] step5: re-render after fix');
+      t = Date.now();
       ({ buffer, pages } = await renderPDF(tailored));
+      console.log(`[tailor] step5: re-render done in ${Date.now() - t}ms`);
+
+      console.log('[tailor] step6: re-validate after fix');
+      t = Date.now();
       validation = validateResume(tailored);
+      console.log(`[tailor] step6: re-validate done in ${Date.now() - t}ms`);
     }
+
+    console.log(
+      `[tailor] pipeline complete: valid=${validation.valid} score=${validation.score} pages=${pages} fixesApplied=${fixesApplied.length}`
+    );
 
     return NextResponse.json({
       success: true,
@@ -70,6 +102,7 @@ export async function POST(req: NextRequest) {
       pdfBase64: buffer.toString('base64'),
     });
   } catch (err) {
+    console.error('[tailor] pipeline error:', err instanceof Error ? err.stack : err);
     const message = err instanceof Error ? err.message : 'Unknown error';
     return NextResponse.json({ error: message }, { status: 500 });
   }

--- a/src/lib/pdf/render-latex-pdf.ts
+++ b/src/lib/pdf/render-latex-pdf.ts
@@ -12,17 +12,27 @@ export async function renderLatexPDF(tex: string): Promise<{ buffer: Buffer; pag
     const texFile = join(dir, "resume.tex");
     await writeFile(texFile, tex, "utf8");
 
-    await execFileAsync("pdflatex", [
-      "-interaction=nonstopmode",
-      "-output-directory",
-      dir,
-      texFile,
-    ]);
+    console.log(`[tailor] step5: invoking pdflatex in ${dir}`);
+    try {
+      await execFileAsync("pdflatex", [
+        "-interaction=nonstopmode",
+        "-output-directory",
+        dir,
+        texFile,
+      ]);
+      console.log("[tailor] step5: pdflatex exited 0");
+    } catch (err) {
+      const execErr = err as { code?: number; stderr?: string };
+      console.error(`[tailor] step5: pdflatex exited ${execErr.code ?? "unknown"}`);
+      if (execErr.stderr) console.error("[tailor] step5: pdflatex stderr:", execErr.stderr);
+      throw err;
+    }
 
     const pdfFile = join(dir, "resume.pdf");
     const buffer = await readFile(pdfFile);
 
     const pages = (buffer.toString("binary").match(/\/Type\s*\/Page[^s]/g) ?? []).length || 1;
+    console.log(`[tailor] step5: PDF ${Math.round(buffer.length / 1024)}kb, ${pages} page${pages === 1 ? "" : "s"}`);
 
     return { buffer, pages };
   } finally {

--- a/src/lib/pipeline/step4-tailor.ts
+++ b/src/lib/pipeline/step4-tailor.ts
@@ -10,18 +10,34 @@ export async function tailorResume(
   const anthropic = client ?? new Anthropic();
   const prompt = buildPrompt({ profile, jobDescription });
 
+  const model = "claude-opus-4-6";
+  const t0 = Date.now();
   const message = await anthropic.messages.create({
-    model: "claude-opus-4-6",
+    model,
     max_tokens: 8192,
     messages: [{ role: "user", content: prompt }],
   });
+  const elapsed = Date.now() - t0;
+
+  const { input_tokens, output_tokens } = message.usage;
+  console.log(
+    `[tailor] step4: model=${model} responded in ${elapsed}ms, ${input_tokens} input tokens, ${output_tokens} output tokens`
+  );
 
   const content = message.content[0];
   if (content.type !== "text") {
     throw new Error("Unexpected response type from Claude");
   }
 
-  return JSON.parse(extractJson(content.text)) as TailoredResume;
+  let parsed: TailoredResume;
+  try {
+    parsed = JSON.parse(extractJson(content.text)) as TailoredResume;
+    console.log("[tailor] step4: JSON parse success");
+  } catch (err) {
+    console.error("[tailor] step4: JSON parse failed", err);
+    throw err;
+  }
+  return parsed;
 }
 
 function extractJson(text: string): string {

--- a/src/lib/pipeline/step6-validate.ts
+++ b/src/lib/pipeline/step6-validate.ts
@@ -56,5 +56,13 @@ export function validateResume(tailored: TailoredResume): ValidationResult {
   }
 
   const score = Math.max(0, 100 - errors.length * 15 - warnings.length * 5);
-  return { valid: errors.length === 0, errors, warnings, score };
+  const result: ValidationResult = { valid: errors.length === 0, errors, warnings, score };
+
+  console.log(
+    `[tailor] step6: valid=${result.valid} score=${score} errors=${errors.length} warnings=${warnings.length}`
+  );
+  if (errors.length) console.log("[tailor] step6: errors:", errors);
+  if (warnings.length) console.log("[tailor] step6: warnings:", warnings);
+
+  return result;
 }

--- a/src/lib/pipeline/step6b-fix.ts
+++ b/src/lib/pipeline/step6b-fix.ts
@@ -8,6 +8,10 @@ export async function fixResume(
 ): Promise<{ tailored: TailoredResume; fixesApplied: string[] }> {
   const anthropic = client ?? new Anthropic();
 
+  console.log(
+    `[tailor] step6b: fix attempt, errors=${validation.errors.length} warnings=${validation.warnings.length}`
+  );
+
   const errorLines = validation.errors.map((e) => `- ${e}`).join("\n");
   const warningLines = validation.warnings.map((w) => `- ${w}`).join("\n");
 
@@ -41,15 +45,19 @@ ${warningLines || "(none)"}
   const text = content.text;
   const fixesApplied = [...validation.errors, ...validation.warnings];
 
+  let tailoredFixed: TailoredResume;
   const fenceMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/);
   if (fenceMatch) {
-    return { tailored: JSON.parse(fenceMatch[1].trim()) as TailoredResume, fixesApplied };
+    tailoredFixed = JSON.parse(fenceMatch[1].trim()) as TailoredResume;
+  } else {
+    const start = text.indexOf("{");
+    const end = text.lastIndexOf("}");
+    if (start === -1 || end === -1) {
+      throw new Error("No JSON found in fix response");
+    }
+    tailoredFixed = JSON.parse(text.slice(start, end + 1)) as TailoredResume;
   }
 
-  const start = text.indexOf("{");
-  const end = text.lastIndexOf("}");
-  if (start === -1 || end === -1) {
-    throw new Error("No JSON found in fix response");
-  }
-  return { tailored: JSON.parse(text.slice(start, end + 1)) as TailoredResume, fixesApplied };
+  console.log(`[tailor] step6b: fixes applied (${fixesApplied.length}):`, fixesApplied);
+  return { tailored: tailoredFixed, fixesApplied };
 }


### PR DESCRIPTION
## Summary

- **route.ts**: Logs request start (targetPages, JD length), each pipeline step start/end with duration (ms), pipeline completion summary, and errors with full stack traces
- **step4-tailor.ts**: Logs Claude model name, input/output token counts, elapsed time, and JSON parse success/failure
- **render-latex-pdf.ts**: Logs pdflatex invocation path, exit code (0 or error code + stderr), and output PDF size in kb with page count
- **step6-validate.ts**: Logs valid/score/errors/warnings counts and their values
- **step6b-fix.ts**: Logs fix attempt with error/warning counts, and the list of fixes applied on completion

All log lines use the `[tailor]` prefix format per the issue spec.

Closes #45

## Test plan

- [ ] Trigger a tailor request and verify `[tailor] request start:` appears in server logs
- [ ] Verify step4 logs show model, token counts, and elapsed ms
- [ ] Verify step5 logs show pdflatex path and PDF size/pages
- [ ] Verify step6 logs show valid/score/counts
- [ ] Trigger a validation failure (malformed profile) and verify step6b logs appear
- [ ] Verify `console.error` fires with stack on pipeline errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)